### PR TITLE
docs: add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,29 @@ Unofficial [poimandres](https://github.com/z0al/poimandres-alacritty/) theme for
 
 ## Installation
 
-Copy the content of either poimandres-storm or poimandres to `~/.config/ghostty/config`.
+Run the following command:
+
+### For `poimandres` (default colorscheme)
+```bash
+curl -o ~/.config/ghostty/themes https://raw.githubusercontent.com/LucidMach/poimandres-ghostty/refs/heads/master/poimandres
+```
+
+### For `poimandres-storm` (colorscheme variation)
+```bash
+curl -o ~/.config/ghostty/themes https://raw.githubusercontent.com/LucidMach/poimandres-ghostty/refs/heads/master/poimandres-storm
+```
+
+## Usage
+
+- Open your Ghostty config file. It can either be done through the UI:
+<img width="288" alt="image" src="https://github.com/user-attachments/assets/71be5833-230b-485d-9d0c-3a1e618134b7" />
+
+Or by pressing `⌘ ,`.
+
+- Set the theme by adding `theme=poimandres` or `theme=poimandres-storm` to the config file.
+- Save it and reload the config using the `⇧ ⌘ ,` combination. It should reflect it afterwards.
+- You're set!
+
 
 ## Related
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Run the following command:
 
 ### For `poimandres` (default colorscheme)
 ```bash
-curl -o ~/.config/ghostty/themes https://raw.githubusercontent.com/LucidMach/poimandres-ghostty/refs/heads/master/poimandres
+curl -o ~/.config/ghostty/themes/poimandres https://raw.githubusercontent.com/LucidMach/poimandres-ghostty/refs/heads/master/poimandres
 ```
 
 ### For `poimandres-storm` (colorscheme variation)
 ```bash
-curl -o ~/.config/ghostty/themes https://raw.githubusercontent.com/LucidMach/poimandres-ghostty/refs/heads/master/poimandres-storm
+curl -o ~/.config/ghostty/themes/poimandres-storm https://raw.githubusercontent.com/LucidMach/poimandres-ghostty/refs/heads/master/poimandres-storm
 ```
 
 ## Usage


### PR DESCRIPTION
This PR slightly enhances the README file to include the installation steps. New Ghostty users can find it to be cumbersome, and the themes dir wasn't right.

Thanks for the colorscheme! It works wonders. If there's room for it, I can help adding the light colorscheme as well.